### PR TITLE
Added `undo_meaning` and `redo_meaning`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "advancedresearch-utility_programming"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 keywords = ["ai", "utility", "programming", "optimization", "advancedresearch"]
 description = "A library for composable utility programming."


### PR DESCRIPTION
This is required to preserve meaning of modifiers when a change from
one modifier alters the meaning of another.